### PR TITLE
Add build definition for 2.1.1-github

### DIFF
--- a/support/2.1.1-github
+++ b/support/2.1.1-github
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.1.1-github" "https://github.com/github/ruby.git" 2_1_1 ldflags_dirs autoconf standard verify_openssl
+install_git "ruby-2.1.1-github" "https://github.com/github/ruby.git" v2_1_1 ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
Currently broken: https://github.com/sstephenson/ruby-build/issues/537
